### PR TITLE
Added duplicated GeneFamily member information to LevelComparisonResult

### DIFF
--- a/familyanalyzer/familyanalyzer.py
+++ b/familyanalyzer/familyanalyzer.py
@@ -285,6 +285,9 @@ class GeneFamily(object):
     def __eq__(self, other):
         return self._cmp() == other._cmp()
 
+    def __str__(self):
+        return self.root.get('og')
+
     def prefix_match(self, other):
         query = self._cmp()
         target = other._cmp()
@@ -717,16 +720,17 @@ class FamEvent(object):
     event = None
 
     def __init__(self, fam):
+        self.name = str(fam)
         self.fam = fam
 
     def __str__(self):
-        return "{}: {}\n".format(self.fam, self.event)
+        return "{}: {}\n".format(self.name, self.event)
 
     def __eq__(self, other):
-        return self.fam == other.fam and self.event == other.event
+        return self.name == other.name and self.event == other.event
 
     def __repr__(self):
-        return "{}: {}".format(self.fam, self.event)
+        return "{}: {}".format(self.name, self.event)
 
 
 class FamIdent(FamEvent):
@@ -753,9 +757,9 @@ class FamDupl(FamEvent):
     def __init__(self, fam, subfam):
         super().__init__(fam)
         if isinstance(subfam, list):
-            subfam_names = "; ".join([s.getFamId() for s in subfam])
+            subfam_names = "; ".join([str(s) for s in subfam])
         else:
-            subfam_names = subfam.getFamId()
+            subfam_names = str(subfam)
         self.into = subfam_names
         self.subfams = subfam
 
@@ -810,16 +814,11 @@ class LevelComparisonResult(object):
     @staticmethod
     def sort_key(item):
 
-        if isinstance(item.fam, str):
-            fam = item.fam
-        else:
-            fam = item.fam.getFamId()
-
-        if fam == 'n/a':
+        if item.name == 'n/a':
             return (MAXINT,)
 
         return tuple((int(num) if num else alpha) for
-                    (num, alpha) in re.findall(r'(\d+)|(\D+)', fam))
+                    (num, alpha) in re.findall(r'(\d+)|(\D+)', item.name))
 
     def group_sort_key(self, item):
         return tuple(itertools.chain((self.group_key(item),),
@@ -851,10 +850,7 @@ class LevelComparisonResult(object):
         return sorted(self.fams_dict.values(), key=self.sort_key)
 
     def addFamily(self, famEvent):
-        if isinstance(famEvent.fam, str):
-            self.fams_dict[famEvent.fam] = famEvent
-        else:
-            self.fams_dict[famEvent.fam.getFamId()] = famEvent
+            self.fams_dict[famEvent.name] = famEvent
 
     def write(self, fd):
         fd.write("\nLevelComparisonResult between taxlevel {} and {}\n".

--- a/familyanalyzer/familyanalyzer.py
+++ b/familyanalyzer/familyanalyzer.py
@@ -664,8 +664,7 @@ class Comparer(object):
             self.advance_i2()
             if self.f2 is None:
                 break
-        self.comp.addFamily(FamDupl(self.f1.getFamId(),
-            '; '.join(gf.getFamId() for gf in m)))
+        self.comp.addFamily(FamDupl(self.f1, m))
         self.advance_i1()
 
     def lost(self):
@@ -754,15 +753,39 @@ class FamDupl(FamEvent):
     def __init__(self, fam, subfam):
         super().__init__(fam)
         if isinstance(subfam, list):
-            subfam = "; ".join(subfam)
-        self.into = subfam
+            subfam_names = "; ".join([s.getFamId() for s in subfam])
+        else:
+            subfam_names = subfam.getFamId()
+        self.into = subfam_names
+        self.subfams = subfam
 
     def __str__(self):
-        return "{} --> {}\n".format(self.fam, self.into)
+        return self.write()
 
     def __eq__(self, other):
         return super().__eq__(other) and self.into == other.into
 
+    def write(self):
+        ''' Construct output for printing. Shows the ids of the duplicated
+            GeneFamily and the resulting subfamilies. It also lists the
+            members of the original GeneFamily and the new subfamilies.
+            Sample output:
+            -------
+            114 --> 114.2a; 114.2b
+            114: 47953; 28082; 11418; 29862; 117; 50097; 13634; 50845; 14300
+            114.2a: 50097; 13634
+            114.2b: 50845; 14300
+            -------
+        '''
+        output = "-------\n"
+        output += ("{} --> {}\n".format(self.fam.getFamId(), self.into))
+        members = "; ".join(self.fam.getMemberGenes())
+        output += ("{}: {}\n".format(self.fam.getFamId(), members))
+        for group in self.subfams:
+            members = "; ".join(group.getMemberGenes())
+            output += ("{}: {}\n".format(group.getFamId(), members))
+        output += ("-------\n")
+        return output
 
 class LevelComparisonResult(object):
 
@@ -786,10 +809,17 @@ class LevelComparisonResult(object):
 
     @staticmethod
     def sort_key(item):
-        if item.fam == 'n/a':
+
+        if isinstance(item.fam, str):
+            fam = item.fam
+        else:
+            fam = item.fam.getFamId()
+
+        if fam == 'n/a':
             return (MAXINT,)
+
         return tuple((int(num) if num else alpha) for
-                    (num, alpha) in re.findall(r'(\d+)|(\D+)', item.fam))
+                    (num, alpha) in re.findall(r'(\d+)|(\D+)', fam))
 
     def group_sort_key(self, item):
         return tuple(itertools.chain((self.group_key(item),),
@@ -821,7 +851,10 @@ class LevelComparisonResult(object):
         return sorted(self.fams_dict.values(), key=self.sort_key)
 
     def addFamily(self, famEvent):
-        self.fams_dict[famEvent.fam] = famEvent
+        if isinstance(famEvent.fam, str):
+            self.fams_dict[famEvent.fam] = famEvent
+        else:
+            self.fams_dict[famEvent.fam.getFamId()] = famEvent
 
     def write(self, fd):
         fd.write("\nLevelComparisonResult between taxlevel {} and {}\n".

--- a/test/test_familyanalyzer.py
+++ b/test/test_familyanalyzer.py
@@ -240,7 +240,7 @@ class TwoLineageComparisons(unittest.TestCase):
         for i in range(len(levPairs)):
             lev1, lev2 = levPairs[i]
             comp = self.compareLevels(lev1, lev2)
-            comp.fams.sort(key=lambda x: x.fam)
+            comp.fams.sort(key=lambda x: x.name)
             self.assertListEqual(comp.fams, expRes[i], 'failed for {} vs {}'.format(lev1, lev2))
 
     def test_summarise(self):
@@ -278,7 +278,7 @@ class TwoLineageComparisons(unittest.TestCase):
         for i in range(len(levPairs)):
             lev1, lev2 = levPairs[i]
             comp = self.compareLevelsSingletonAware(lev1, lev2)
-            comp.fams.sort(key=lambda x: x.fam)
+            comp.fams.sort(key=lambda x: x.name)
             self.assertListEqual(comp.fams, expRes[i], 'failed for {} vs {}'.format(lev1, lev2))
 
     def test_summarise_singleton_aware(self):


### PR DESCRIPTION
Dear all,

I have added functionality to the LevelComparisonResult Class to print the members of a duplicated GeneFamily, and the members of the new sub-families. Previously it would only show that a duplication event occurred at a given node, but not the content of these families.

Sample output for a duplicated family, when printing the results of
a LevelComparison looks like this:

```
....
112: lost
113: identical
-------
114 --> 114.2a; 114.2b
114: 47953; 28082; 11418; 29862; 117; 50097; 13634; 50845; 14300
114.2a: 50097; 13634
114.2b: 50845; 14300
-------
...
```

The changes also enhance the FamDupl object, which now uses GeneFamily objects, rather than the LOFT annotation. This allows the retention of the GeneFamily information, which can be easily accessed using the LevelComparisonResult.filter() function. Additional modifications would be needed for all other FamEvent children (eg. FamLost, FamIdent etc.) If this is something that would be useful, I would be happy to work on this.

If anything is unclear, or futher modifications are requested, just let me know!

Best,
Fabian
